### PR TITLE
Add cookie consent banner

### DIFF
--- a/public/App.vue
+++ b/public/App.vue
@@ -4,6 +4,7 @@ import AppHeader from '@/components/AppHeader.vue'
 import AppBottomBar from '@/components/AppBottomBar.vue'
 import AppFooter from '@/components/AppFooter.vue'
 import AppointmentPopup from '@/components/AppointmentPopup.vue'
+import CookieConsent from '@/components/CookieConsent.vue'
 
 const popupOpen = ref(false)
 function openPopup() { popupOpen.value = true }
@@ -17,6 +18,7 @@ provide('openAppointmentPopup', openPopup)
   <router-view />
   <AppBottomBar @contact="openPopup" />
   <AppFooter />
+  <CookieConsent />
   <AppointmentPopup v-model:isOpen="popupOpen" />
 </template>
 

--- a/public/components/CookieConsent.vue
+++ b/public/components/CookieConsent.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const visible = ref(false)
+
+onMounted(() => {
+  const hasConsent = document.cookie.split('; ').find(row => row.startsWith('cookie_consent='))
+  if (!hasConsent) visible.value = true
+})
+
+function acceptCookies() {
+  const expires = new Date(Date.now() + 365*24*60*60*1000).toUTCString()
+  document.cookie = `cookie_consent=true; expires=${expires}; path=/`
+  visible.value = false
+}
+</script>
+
+<template>
+  <transition name="slide-up">
+    <div v-if="visible" class="cookie-consent">
+      <p>Χρησιμοποιούμε cookies για να βελτιώσουμε την εμπειρία σας.</p>
+      <button class="cookie-btn" @click="acceptCookies">Αποδοχή</button>
+    </div>
+  </transition>
+</template>
+
+<style scoped>
+.cookie-consent {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+  border: 1px solid #e6e8eb;
+  box-shadow: 0 4px 20px rgba(50,70,100,0.07);
+  padding: 14px 18px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 90vw;
+  z-index: 10000;
+  text-align: center;
+  font-size: 0.95rem;
+}
+.cookie-btn {
+  align-self: center;
+  background: #044877;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  padding: 8px 18px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+.cookie-btn:hover {
+  background: #03365d;
+}
+.slide-up-enter-active, .slide-up-leave-active {
+  transition: transform 0.3s, opacity 0.3s;
+}
+.slide-up-enter-from, .slide-up-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- add cookie consent component with local cookie storage
- include cookie banner in App.vue

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1d41fa908325aa0062bfaab79f0a